### PR TITLE
support set selection=exclusive

### DIFF
--- a/plugin/substitute.vim
+++ b/plugin/substitute.vim
@@ -17,11 +17,16 @@ endfunction
 function! s:SubstituteMotion(type, ...)
 
     let startPos = getpos('.')
+    if &selection ==# 'exclusive'
+      let excl_right = "\<right>"
+    else
+      let excl_right = ""
+    endif
 
     if a:type ==# 'line'
-        exe "normal! '[V']"
+        exe "normal! '[V']".excl_right
     elseif a:type ==# 'char'
-        exe "normal! `[v`]"
+        exe "normal! `[v`]".excl_right
     else
         echom "Unexpected selection type"
         return

--- a/plugin/yank.vim
+++ b/plugin/yank.vim
@@ -82,12 +82,17 @@ endfunction
 
 function! s:YankMotion(type)
     let oldValue = getreg(s:activeRegister)
+    if &selection ==# 'exclusive'
+      let excl_right = "\<right>"
+    else
+      let excl_right = ""
+    endif
 
     EasyClipBeforeYank
     if a:type ==# 'line'
-        silent exe "keepjumps normal! `[V`]\"".s:activeRegister."y"
+        silent exe "keepjumps normal! `[V`]".excl_right."\"".s:activeRegister."y"
     elseif a:type ==# 'char'
-        silent exe "keepjumps normal! `[v`]\"".s:activeRegister."y"
+        silent exe "keepjumps normal! `[v`]".excl_right."\"".s:activeRegister."y"
     else
         echom "Unexpected selection type"
         return


### PR DESCRIPTION
My vim (terminal vim) uses `set selection=exclusive` mode, so that the selection looks like gvim. We need to move `<right>` to support this selection mode.
