### PR TITLE
Add g:EasyClipUseBlackHoleDefaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ You can also disable the default mappings by setting one or more of the followin
     `g:EasyClipUsePasteDefaults`
     
     `g:EasyClipUseSubstituteDefaults`
+    
+    `g:EasyClipUseBlackHoleDefaults`
 
 You can then map to the specific `<plug>` mappings to define whatever mappings you want.  For example, to change the mapping for cut (by default set to `m`) to `yd`, include the following in your vimrc:`
 

--- a/doc/easyclip.txt
+++ b/doc/easyclip.txt
@@ -148,6 +148,7 @@ You can also disable the default mappings by setting one or more of the followin
     g:EasyClipUseCutDefaults
     g:EasyClipUsePasteDefaults
     g:EasyClipUseSubstituteDefaults
+    g:EasyClipUseBlackHoleDefaults
 
 You can then map to the specific `<plug>` mappings to define whatever mappings
 you want.  For example, to change the mapping for cut (by default set to `m`) to

--- a/plugin/blackhole.vim
+++ b/plugin/blackhole.vim
@@ -1,47 +1,49 @@
+if !exists('g:EasyClipUseBlackHoleDefaults') || g:EasyClipUseBlackHoleDefaults
 
-nnoremap d "_d
-nnoremap dd "_dd
+  nnoremap d "_d
+  nnoremap dd "_dd
 
-nnoremap dD 0"_d$
+  nnoremap dD 0"_d$
 
-noremap x "_x
-xnoremap x "_x
+  noremap x "_x
+  xnoremap x "_x
 
-xnoremap d "_d
+  xnoremap d "_d
 
-nnoremap c "_c
-xnoremap c "_c
+  nnoremap c "_c
+  xnoremap c "_c
 
-" This is more consistent with yy and dd
-nnoremap cc "_S
-nnoremap cC "_S
+  " This is more consistent with yy and dd
+  nnoremap cc "_S
+  nnoremap cC "_S
 
-if !exists('g:EasyClipRemapCapitals') || g:EasyClipRemapCapitals
-    nnoremap C "_C
-    xnoremap C "_C
+  if !exists('g:EasyClipRemapCapitals') || g:EasyClipRemapCapitals
+      nnoremap C "_C
+      xnoremap C "_C
 
-    nnoremap D "_d$
-    xnoremap D <nop>
+      nnoremap D "_d$
+      xnoremap D <nop>
+  endif
+
+  function! s:AddBlackHoleSelectBindings()
+
+      let i = 33
+
+      " Add a map for every printable character to copy to black hole register
+      " I see no easier way to do this
+      while i <= 126
+          if i !=# 124
+              let char = nr2char(i)
+              exec 'snoremap '. char .' <c-o>"_c'. char
+          endif
+
+          let i = i + 1
+      endwhile
+
+      snoremap <space> <c-o>"_c<space>
+      snoremap \| <c-o>"_c|
+  endfunction
+
+  call <sid>AddBlackHoleSelectBindings()
 endif
-
-function! s:AddBlackHoleSelectBindings()
-
-    let i = 33
-
-    " Add a map for every printable character to copy to black hole register
-    " I see no easier way to do this
-    while i <= 126
-        if i !=# 124
-            let char = nr2char(i)
-            exec 'snoremap '. char .' <c-o>"_c'. char
-        endif
-
-        let i = i + 1
-    endwhile
-
-    snoremap <space> <c-o>"_c<space>
-    snoremap \| <c-o>"_c|
-endfunction
-
-call <sid>AddBlackHoleSelectBindings()
 


### PR DESCRIPTION
Add `g:EasyClipUseBlackHoleDefaults` (best to view this with whitespace ignored: https://github.com/svermeulen/vim-easyclip/pull/12?w=1)
