### PR TITLE
Add readme and doc notice about [y and ]y not on. Don't generate helptags for [y and ]y

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,7 @@ By default, the keys to toggle the paste are mapped to `<c-n>` and `<c-p>` (simi
 
 This method of toggling the chosen yank after paste will probably be your primary method of digging back into the yank buffer.  Note that in this case the yank buffer is unchanged.  What this means for example is that you can toggle a given paste back using `<c-p>` 10 times, then if you perform a new paste in a different location it will still use the most recent yank (and not the final yank you arrived at after 10 swaps).
 
-Alternatively, you can execute (by default) keys `[y` or `]y` to navigate the
-yank buffer 'head' forwards or backwards.  In this case the change will be
-permanent.  That is, pressing `[y[yp` will paste the third most recent yank.
-Subsequent pastes will use the same yank, until you go forwards again using
-`]y`.
+Alternatively, you can execute (by default) keys `[y` or `]y` to navigate the yank buffer 'head' forwards or backwards.  In this case the change will be permanent.  That is, pressing `[y[yp` will paste the third most recent yank. Subsequent pastes will use the same yank, until you go forwards again using `]y`.
 
 The [y and ]y mappings are not on by default (map them manually).
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default, the keys to toggle the paste are mapped to `<c-n>` and `<c-p>` (simi
 
 This method of toggling the chosen yank after paste will probably be your primary method of digging back into the yank buffer.  Note that in this case the yank buffer is unchanged.  What this means for example is that you can toggle a given paste back using `<c-p>` 10 times, then if you perform a new paste in a different location it will still use the most recent yank (and not the final yank you arrived at after 10 swaps).
 
-Alternatively, you can execute (by default) keys `[y` or `]y` to navigate the yank buffer 'head' forwards or backwards.  In this case the change will be permanent.  That is, pressing `[y[yp` will paste the third most recent yank. Subsequent pastes will use the same yank, until you go forwards again using `]y`.
+Alternatively, you can execute keys `[y` or `]y` to navigate the yank buffer 'head' forwards or backwards.  In this case the change will be permanent.  That is, pressing `[y[yp` will paste the third most recent yank. Subsequent pastes will use the same yank, until you go forwards again using `]y`.
 
 The [y and ]y mappings are not on by default (map them manually).
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ By default, the keys to toggle the paste are mapped to `<c-n>` and `<c-p>` (simi
 
 This method of toggling the chosen yank after paste will probably be your primary method of digging back into the yank buffer.  Note that in this case the yank buffer is unchanged.  What this means for example is that you can toggle a given paste back using `<c-p>` 10 times, then if you perform a new paste in a different location it will still use the most recent yank (and not the final yank you arrived at after 10 swaps).
 
-Alternatively, you can execute (by default) keys `[y` or `]y` to navigate the yank buffer 'head' forwards or backwards.  In this case the change will be permanent.  That is, pressing `[y[yp` will paste the third most recent yank.  Subsequent pastes will use the same yank, until you go forwards again using `]y`.
+Alternatively, you can execute (by default) keys `[y` or `]y` to navigate the
+yank buffer 'head' forwards or backwards.  In this case the change will be
+permanent.  That is, pressing `[y[yp` will paste the third most recent yank.
+Subsequent pastes will use the same yank, until you go forwards again using
+`]y`.
+
+The [y and ]y mappings are not on by default (map them manually).
 
 You can view the full list of yanks at any time by running the command `:Yanks`
 

--- a/doc/easyclip.txt
+++ b/doc/easyclip.txt
@@ -116,10 +116,12 @@ toggle a given paste back using `<c-p>` 10 times, then if you perform a new
 paste in a different location it will still use the most recent yank (and not 
 the final yank you arrived at after 10 swaps).
 
-Alternatively, you can execute (by default) keys `[y` or `]y` to navigate the 
-yank buffer 'head' forwards or backwards.  In this case the change will be 
-permanent.  That is, pressing `[y[yp` will paste the third most recent yank.  
+Alternatively, you can execute keys `[y` or `]y` to navigate the yank buffer
+'head' forwards or backwards. In this case the change will be permanent.
+That is, pressing `[y[yp` will paste the third most recent yank.  
 Subsequent pastes will use the same yank, until you go forwards again using `]y`.
+
+The [y and ]y mappings are not on by default (map them manually).
 
 You can view the full list of yanks at any time by running the command `:Yanks`
 
@@ -339,10 +341,6 @@ KEY MAPPINGS                                    *easyclip-mappings*
 *<c-p>* -p>' - Rotate the previous paste forward in yank buffer.  Note that this binding will only work if executed immediately after a paste
 
 *<c-n>* -n>' - Rotate the previous paste backward in yank buffer.  Note that this binding will only work if executed immediately after a paste
-
-*[y* - Go backward in the yank buffer.  This can be executed at any time to modify order of yanks in the yank buffer (though I would recommend just using '<c-p>' instead)
-
-*]y* - Go forward in the yank buffer. This can be executed at any time to modify order of yanks in the yank buffer (though I would recommend just using '<c-n>' instead)
 
 *Y* - Copy text from cursor position to the end of line to the clipboard
 


### PR DESCRIPTION
Fixes https://github.com/svermeulen/vim-easyclip/issues/46