### PR TITLE
Finalize the solution for the Visual mode paste issue

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -178,8 +178,10 @@ function! EasyClip#Paste#PasteTextVisualMode(reg, count)
         call EasyClip#Shared#LoadFileIfChanged()
         exec "normal! \"_c\<c-r>" . EasyClip#GetDefaultReg()
     else
-        let [op, plugName] = (col('.') < col('$') - 1 || col('$') <= 2) && (line('.') < line('$'))
-                    \ ? ['P', 'EasyClipPasteBefore'] : ['p', 'EasyClipPasteAfter']
+        let lnum = line('''>')
+        let [op, plugName] =
+        \   (col('''>') < col([lnum, '$']) - 1 || col([lnum, '$']) <= 2) && (lnum < line('$'))
+        \   ? ['P', 'EasyClipPasteBefore'] : ['p', 'EasyClipPasteAfter']
         normal! "_d
         call EasyClip#Paste#PasteText(a:reg, a:count, op, 1, plugName)
     endif

--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -180,7 +180,7 @@ function! EasyClip#Paste#PasteTextVisualMode(reg, count)
     else
         let lnum = line('''>')
         let [op, plugName] =
-        \   (col('''>') < col([lnum, '$']) - 1 || col([lnum, '$']) <= 2) && (lnum < line('$'))
+        \   (col('''>') != col([lnum, '$']) - 1) && (lnum != line('$'))
         \   ? ['P', 'EasyClipPasteBefore'] : ['p', 'EasyClipPasteAfter']
         normal! "_d
         call EasyClip#Paste#PasteText(a:reg, a:count, op, 1, plugName)


### PR DESCRIPTION
Hello.

It's me again with the same issue again. You might be a bit irritated with my iterations of fixes for the Visual mode paste problem. I apologize for that.

Anyway, the problem is there and it would be nice to merge another fix that should finally resolve this issue.  My previous pull request was almost complete and proper, but one thing have slipped my attention at the time. Recall that currently vim-easyclip determines the last selection character position by reading the current cursor position after the selection was made. This won't work as intended when the selection was made 'backwards', e.g. with the `vB` command. The proper way to determine the last selection character position is to tackle the `'>` mark. This pull request does exactly that.

Also I was able to eliminate the special handling of the `col([lnum, $]) <= 2` case by changing 'less than' to 'not equal' comparison in `if` clause.

I've tested this PR for a while and there seem to be no problems with Visual mode paste at last.