### PR TITLE
Avoid auto-formatting in blockwise Visual mode single line pastes

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -188,7 +188,7 @@ function! EasyClip#Paste#PasteTextVisualMode(reg, count)
     " If we're pasting a single line yank in visual block mode then repeat paste for each line
     if mode() ==# '' && getreg(a:reg) !~# '\n'
         call EasyClip#Shared#LoadFileIfChanged()
-        exec "normal! \"_c\<c-r>" . EasyClip#GetDefaultReg()
+        exec "normal! \"_c\<C-R>\<C-O>" . EasyClip#GetDefaultReg()
     else
         let lnum = line('''>')
         let [op, plugName] =


### PR DESCRIPTION
The current paste command is `"_c\<C-R> . EasyClip#GetDefaultReg()`. It
can yield undesired results under certain conditions. For example, tabs
in yanked text are replaced with spaces with `expandtab, ts=4, sts=0`.
This happens because `CTRL-R` in Insert mode inserts contents of a
register with respect to various Vim formatting options and we are
brought to Insert mode by the `"_c` command.

As stated in the help for i_CTRL-R:
```
If you have options like 'textwidth', 'formatoptions', or
'autoindent' set, this will influence what will be inserted.
```

Since most people probably want their text pasted unspoiled the proper
paste command is `"_c\<C-R>\<C-O>" . EasyClip#GetDefaultReg()`.

As stated in the help for i_CTRL-R_CTRL-O:
```
Insert the contents of a register literally and don't auto-indent.
```

This commit changes the paste command as described above.