### PR TITLE
Add fallback commands to swap paste.

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -244,7 +244,13 @@ endfunction
 
 function! EasyClip#Paste#SwapPaste(forward)
     if !EasyClip#Paste#WasLastChangePaste()
-        echo 'Last action was not paste, swap ignored'
+        if (a:forward) && exists('g:EasyClipSwapPasteForwardFallback')
+            exec g:EasyClipSwapPasteForwardFallback
+        elseif (!a:forward) && exists('g:EasyClipSwapPasteBackwardsFallback')
+            exec g:EasyClipSwapPasteBackwardsFallback
+        else
+            echo 'Last action was not paste, swap ignored'
+        endif
         return
     endif
 

--- a/doc/easyclip.txt
+++ b/doc/easyclip.txt
@@ -250,6 +250,14 @@ applicable when |g:EasyClipShareYanks| option is enabled.
 *g:EasyClipShowYanksWidth* - Default: 80 - The width to display for each line 
 when the `Yanks` command is executed
 
+*g:EasyClipSwapPasteForwardFallback* - Default: undefined. If set, and the
+previous action was not a paste <Plug>EasyClipSwapPasteForward will exec
+this. Useful if you have muscle memory for a previous use of <c-p>.
+
+*g:EasyClipSwapPasteBackwardsFallback* - Default: undefined. If set, and the
+previous action was not a paste <Plug>EasyClipSwapPasteBackwards will exec
+this. Useful if you have muscle memory for a previous use of <c-n>.
+
 You can also disable the default mappings by setting one or more of the
 following to zero.  By default they are set to 1 (ie. enabled)
 


### PR DESCRIPTION
Hi! I'm liking EasyClip, and thought I'd make this little improvement. It helps me make EasyClip coexist with CtrlP, and may be useful for others. Feedback gladly accepted.

g:EasyClipSwapPasteForwardFallback and g:EasyClipSwapPasteForwardReverse
provide alternative commands for EasyClipSwapPasteForward and
EasyClipSwapPasteBackwards.

This way, someone who has those keys mapped already can use muscle
memory to get the old functions if the previous action wasn't a paste.