### PR TITLE
Fix visual mode paste regression

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -192,7 +192,7 @@ function! EasyClip#Paste#PasteTextVisualMode(reg, count)
     else
         let lnum = line('''>')
         let [op, plugName] =
-        \   (col('''>') != col([lnum, '$']) - 1) && (lnum != line('$'))
+        \   (col('''>') < col([lnum, '$']) - 1 || col([lnum, '$']) <= 2) && (lnum < line('$'))
         \   ? ['P', 'EasyClipPasteBefore'] : ['p', 'EasyClipPasteAfter']
         normal! "_d
         call EasyClip#Paste#PasteText(a:reg, a:count, op, 1, plugName)

--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -191,8 +191,9 @@ function! EasyClip#Paste#PasteTextVisualMode(reg, count)
         exec "normal! \"_c\<C-R>\<C-O>" . EasyClip#GetDefaultReg()
     else
         let lnum = line('''>')
+        let cols = col([lnum, '$'])
         let [op, plugName] =
-        \   (col('''>') < col([lnum, '$']) - 1 || col([lnum, '$']) <= 2) && (lnum < line('$'))
+        \   (col('''>') <= cols - 2 || cols <= 2) && (lnum < line('$'))
         \   ? ['P', 'EasyClipPasteBefore'] : ['p', 'EasyClipPasteAfter']
         normal! "_d
         call EasyClip#Paste#PasteText(a:reg, a:count, op, 1, plugName)


### PR DESCRIPTION
Revert 477ca2f.
It introduced changes that made selections extending past the visible
line end, i.e. up to `col([lnum,'$'])`, not being handled properly.

Calculate `col([lnum, '$'])` once.