### PR TITLE
Another fix for characterwise Visual mode paste

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -198,7 +198,9 @@ function! EasyClip#Paste#PasteTextVisualMode(reg, count)
         " See here for an explanation of this code:
         " https://github.com/svermeulen/vim-easyclip/wiki/Details-of-Visual-mode-paste
         if vmode ==# 'v'
-            let shouldPasteBefore = (cnum != cols - 1 && (lnum != line('$') || cnum != cols))
+            let shouldPasteBefore =
+                \ (cnum != cols - 1 && (lnum != line('$') || cnum != cols)) &&
+                \ (cnum != cols || col([lnum + 1, '$']) != 1)
         elseif vmode ==# 'V'
             let shouldPasteBefore = (lnum != line('$'))
         elseif vmode ==# ''


### PR DESCRIPTION
Guess who's back?

If the selection ends at the EOL character of a line and the next line
is empty (`^$`), then after deletion the cursor is placed on the
previous character before the first character of the selection. Thus in
this case we should do pasting after, not before.

Note that if `lnum` points to the last line, then `col([lnum + 1, '$'])`
returns `0`. So there is no need for an additional check if we are on
the last line.

I've added the relevant info and example at https://github.com/svermeulen/vim-easyclip/wiki/Details-of-Visual-mode-paste#characterwise-visual-mode