### PR TITLE
Load the plugin only once

### DIFF
--- a/plugin/EasyClip.vim
+++ b/plugin/EasyClip.vim
@@ -1,2 +1,6 @@
+if exists('g:loaded_EasyClip')
+	finish
+endif
+let g:loaded_EasyClip = 1
 
 call EasyClip#Init()


### PR DESCRIPTION
Also, the de-facto default of having a `loaded_<PluginName>` variable
helps a lot when checking if the plugin loaded.