### PR TITLE
paste: preserve selection when pasting in Visual mode

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -229,8 +229,13 @@ function! EasyClip#Paste#PasteTextVisualMode(reg, count)
         endif
 
         let [op, plugName] = shouldPasteBefore ? ['P', 'EasyClipPasteBefore'] : ['p', 'EasyClipPasteAfter']
+        let l:save_selection = [getpos('''<'), getpos('''>')]
+
         normal! "_d
         call EasyClip#Paste#PasteText(a:reg, a:count, op, 1, plugName)
+
+        call setpos('''<', l:save_selection[0])
+        call setpos('''>', l:save_selection[1])
     endif
 endfunction
 


### PR DESCRIPTION
Simply save/restore relevant marks otherwise "_d will screw things up.
