### PR TITLE
Added check for &modifiable before trying paste

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -66,6 +66,9 @@ nnoremap <silent> <plug>EasyClipToggleFormattedPaste :call EasyClip#Paste#Toggle
 " inline = 1 if we should paste multiline text inline.
 " That is, add the newline wherever the cursor is rather than above/below the current line
 function! EasyClip#Paste#Paste(op, format, reg, inline)
+    if !&modifiable
+        return
+    endif
 
     " This shouldn't be necessary since we calling this on FocusGained but
     " we call it here anyway since some console vims don't fire FocusGained


### PR DESCRIPTION
Before:
When trying to paste in a buffer where &modifiable == 0, EasyClip would
produce the following error:

    Error detected while processing function EasyClip#Paste#PasteText[14]..EasyClip#Paste#Paste:
    line   42:
    E21: Cannot make changes, 'modifiable' is off
    Press ENTER or type command to continue

After:
silence