### PR TITLE
Added 'X' to black hole delete bindings.

### DIFF
--- a/autoload/EasyClip/BlackHole.vim
+++ b/autoload/EasyClip/BlackHole.vim
@@ -28,6 +28,7 @@ function! EasyClip#BlackHole#AddDeleteBindings()
     \   ['dD', '0"_d$', 'n'],
     \   ['D', '"_D', 'nx'],
     \   ['x', '"_x', 'nx'],
+    \   ['X', '"_X', 'nx'],
     \ ]
 
     for binding in bindings


### PR DESCRIPTION
I have added upper-case 'X' to the black hole delete bindings list, since it was missing, and I can't see why not including it would be intended behavior.