### PR TITLE
Allow pasting to Neovim terminal

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -67,7 +67,7 @@ nnoremap <silent> <plug>EasyClipToggleFormattedPaste :call EasyClip#Paste#Toggle
 " inline = 1 if we should paste multiline text inline.
 " That is, add the newline wherever the cursor is rather than above/below the current line
 function! EasyClip#Paste#Paste(op, format, reg, inline)
-    if !&modifiable
+    if !&modifiable && &buftype != 'terminal'
         return
     endif
 


### PR DESCRIPTION
Neovim terminals are not modifiable, but you can still paste to them.