### PR TITLE
Bind mappings for each buffer

### DIFF
--- a/autoload/EasyClip.vim
+++ b/autoload/EasyClip.vim
@@ -53,7 +53,7 @@ function! EasyClip#AddWeakMapping(left, right, modes, ...)
     let recursive = a:0 > 0 ? a:1 : 0
 
     for mode in split(a:modes, '\zs')
-        if !EasyClip#HasMapping(a:left, mode)
+        if &modifiable && !EasyClip#HasMapping(a:left, mode)
             exec mode . (recursive ? "map" : "noremap") . " <silent> " . a:left . " " . a:right
         endif
     endfor
@@ -154,12 +154,12 @@ function! EasyClip#Init()
     augroup easyclip_checkdependencies
         autocmd!
         autocmd VimEnter * call EasyClip#CheckRequiredDependencies()
+        autocmd BufReadPost * call EasyClip#Paste#Init()
+        autocmd BufReadPost * call EasyClip#Move#Init()
+        autocmd BufReadPost * call EasyClip#Substitute#Init()
+        autocmd BufReadPost * call EasyClip#Yank#Init()
     augroup END
 
-    call EasyClip#Paste#Init()
-    call EasyClip#Move#Init()
-    call EasyClip#Substitute#Init()
-    call EasyClip#Yank#Init()
     call EasyClip#Shared#Init()
 
     " Add black hole bindings last so that it only

--- a/autoload/EasyClip/Move.vim
+++ b/autoload/EasyClip/Move.vim
@@ -78,9 +78,9 @@ function! EasyClip#Move#SetDefaultBindings()
 
     let bindings =
     \ [
-    \   ['m',  '<Plug>MoveMotionPlug',  'n',  1],
-    \   ['mm',  '<Plug>MoveMotionLinePlug',  'n',  1],
-    \   ['m',  '<Plug>MoveMotionXPlug',  'x',  1],
+    \   ['<buffer> m',  '<Plug>MoveMotionPlug',  'n',  1],
+    \   ['<buffer> mm',  '<Plug>MoveMotionLinePlug',  'n',  1],
+    \   ['<buffer> m',  '<Plug>MoveMotionXPlug',  'x',  1],
     \ ]
 
     " Leave these commented to avoid shadowing M (go to middle of screen)

--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -344,22 +344,22 @@ function! EasyClip#Paste#SetDefaultMappings()
 
     let bindings =
     \ [
-    \   ['p',  '<plug>XEasyClipPaste',  'x',  1],
-    \   ['P',  '<plug>XEasyClipPaste',  'x',  1],
-    \   ['gp',  '<plug>XG_EasyClipPaste',  'x',  1],
-    \   ['gP',  '<plug>XG_EasyClipPaste',  'x',  1],
-    \   ['<leader>p',  '<plug>XEasyClipPasteUnformatted',  'x',  1],
-    \   ['<leader>P',  '<plug>XEasyClipPasteUnformatted',  'x',  1],
-    \   ['P',  '<plug>EasyClipPasteBefore',  'n',  1],
-    \   ['p',  '<plug>EasyClipPasteAfter',  'n',  1],
-    \   ['gp',  '<plug>G_EasyClipPasteAfter',  'n',  1],
-    \   ['gP',  '<plug>G_EasyClipPasteBefore',  'n',  1],
-    \   ['<leader>p',  '<plug>EasyClipPasteUnformattedAfter',  'n',  1],
-    \   ['<leader>P',  '<plug>EasyClipPasteUnformattedBefore',  'n',  1],
-    \   ['g<leader>p',  '<plug>G_EasyClipPasteUnformattedAfter',  'n',  1],
-    \   ['g<leader>P',  '<plug>G_EasyClipPasteUnformattedBefore',  'n',  1],
-    \   ['<c-p>',  '<plug>EasyClipSwapPasteForward',  'n',  1],
-    \   ['<c-n>',  '<plug>EasyClipSwapPasteBackwards',  'n',  1],
+    \   ['<buffer> p',  '<plug>XEasyClipPaste',  'x',  1],
+    \   ['<buffer> P',  '<plug>XEasyClipPaste',  'x',  1],
+    \   ['<buffer> gp',  '<plug>XG_EasyClipPaste',  'x',  1],
+    \   ['<buffer> gP',  '<plug>XG_EasyClipPaste',  'x',  1],
+    \   ['<buffer> <leader>p',  '<plug>XEasyClipPasteUnformatted',  'x',  1],
+    \   ['<buffer> <leader>P',  '<plug>XEasyClipPasteUnformatted',  'x',  1],
+    \   ['<buffer> P',  '<plug>EasyClipPasteBefore',  'n',  1],
+    \   ['<buffer> p',  '<plug>EasyClipPasteAfter',  'n',  1],
+    \   ['<buffer> gp',  '<plug>G_EasyClipPasteAfter',  'n',  1],
+    \   ['<buffer> gP',  '<plug>G_EasyClipPasteBefore',  'n',  1],
+    \   ['<buffer> <leader>p',  '<plug>EasyClipPasteUnformattedAfter',  'n',  1],
+    \   ['<buffer> <leader>P',  '<plug>EasyClipPasteUnformattedBefore',  'n',  1],
+    \   ['<buffer> g<leader>p',  '<plug>G_EasyClipPasteUnformattedAfter',  'n',  1],
+    \   ['<buffer> g<leader>P',  '<plug>G_EasyClipPasteUnformattedBefore',  'n',  1],
+    \   ['<buffer> <c-p>',  '<plug>EasyClipSwapPasteForward',  'n',  1],
+    \   ['<buffer> <c-n>',  '<plug>EasyClipSwapPasteBackwards',  'n',  1],
     \ ]
 
     for binding in bindings

--- a/autoload/EasyClip/Substitute.vim
+++ b/autoload/EasyClip/Substitute.vim
@@ -132,12 +132,12 @@ function! EasyClip#Substitute#SetDefaultBindings()
 
     let bindings =
     \ [
-    \   ['s',  '<plug>SubstituteOverMotionMap',  'n',  1],
-    \   ['gs',  '<plug>G_SubstituteOverMotionMap',  'n',  1],
-    \   ['ss',  '<plug>SubstituteLine',  'n',  1],
-    \   ['s',  '<plug>XEasyClipPaste',  'x',  1],
-    \   ['S',  '<plug>SubstituteToEndOfLine',  'n',  1],
-    \   ['gS',  '<plug>G_SubstituteToEndOfLine',  'n',  1],
+    \   ['<buffer> s',  '<plug>SubstituteOverMotionMap',  'n',  1],
+    \   ['<buffer> gs',  '<plug>G_SubstituteOverMotionMap',  'n',  1],
+    \   ['<buffer> ss',  '<plug>SubstituteLine',  'n',  1],
+    \   ['<buffer> s',  '<plug>XEasyClipPaste',  'x',  1],
+    \   ['<buffer> S',  '<plug>SubstituteToEndOfLine',  'n',  1],
+    \   ['<buffer> gS',  '<plug>G_SubstituteToEndOfLine',  'n',  1],
     \ ]
 
     for binding in bindings

--- a/autoload/EasyClip/Yank.vim
+++ b/autoload/EasyClip/Yank.vim
@@ -308,10 +308,10 @@ function! EasyClip#Yank#SetDefaultMappings()
 
     let bindings =
     \ [
-    \   ['Y',  ':EasyClipBeforeYank<cr>y$:EasyClipOnYanksChanged<cr>',  'n',  0],
-    \   ['y',  '<Plug>YankPreserveCursorPosition',  'n',  1],
-    \   ['yy',  '<Plug>YankLinePreserveCursorPosition',  'n',  1],
-    \   ['y',  '<Plug>VisualModeYank',  'x',  1],
+    \   ['<buffer> Y',  ':EasyClipBeforeYank<cr>y$:EasyClipOnYanksChanged<cr>',  'n',  0],
+    \   ['<buffer> y',  '<Plug>YankPreserveCursorPosition',  'n',  1],
+    \   ['<buffer> yy',  '<Plug>YankLinePreserveCursorPosition',  'n',  1],
+    \   ['<buffer> y',  '<Plug>VisualModeYank',  'x',  1],
     \ ]
 
     " Let the user set [y themselves so that we don't conflict with vim-unimpaired
@@ -370,9 +370,6 @@ function! EasyClip#Yank#Init()
 
     " Watch focus to keep the shared clipboard in sync for use by other
     " vim sessions
-    augroup _easyclip_focuswatch
-        au!
-        autocmd FocusGained * call EasyClip#Yank#OnFocusGained()
-        autocmd FocusLost * call EasyClip#Yank#OnFocusLost()
-    augroup END
+    autocmd! FocusGained * <buffer> call EasyClip#Yank#OnFocusGained()
+    autocmd! FocusLost * <buffer> call EasyClip#Yank#OnFocusLost()
 endfunction


### PR DESCRIPTION
This would make it so plugins that set their own mappings in buffers shouldn't conflict with easyclip mappings.

One example is NERDTree that uses the `m` key in it's buffer.