### PR TITLE
Fix `EasyClip#HasMapping` for buffer-local mappings

### DIFF
--- a/autoload/EasyClip.vim
+++ b/autoload/EasyClip.vim
@@ -60,7 +60,8 @@ function! EasyClip#AddWeakMapping(left, right, modes, ...)
 endfunction
 
 function! EasyClip#HasMapping(mapping, mode)
-    return maparg(a:mapping, a:mode) != ''
+    let mapping = substitute(a:mapping, '\V\^<buffer> ', '', '')
+    return maparg(mapping, a:mode) != ''
 endfunction
 
 function! EasyClip#GetCurrentYank()


### PR DESCRIPTION
[commit fe7d6a55](https://github.com/svermeulen/vim-easyclip/commit/fe7d6a55f36811b300f93044c2f1c7e9cde31ad3) - which changed the bindings to be local - has broken `EasyClip#HasMapping`. `maparg` was now called for mappings like `'<buffer> p'` - which was taken literally.