### PR TITLE
fix automatic mapping for backslash

### DIFF
--- a/autoload/EasyClip/BlackHole.vim
+++ b/autoload/EasyClip/BlackHole.vim
@@ -8,6 +8,9 @@ function! EasyClip#BlackHole#AddSelectBindings()
     while i <= 126
         if i !=# 124
             let char = nr2char(i)
+            if i ==# 92
+              let char = '\\'
+            endif
             exec 'snoremap '. char .' <c-o>"_c'. char
         endif
 


### PR DESCRIPTION
This prevents an error message on startup.