### PR TITLE
Make more resilient to custom config

### DIFF
--- a/autoload/EasyClip/Move.vim
+++ b/autoload/EasyClip/Move.vim
@@ -48,6 +48,8 @@ function! EasyClip#Move#PreMoveMotion( )
 endfunction
 
 function! EasyClip#Move#MoveMotion(type)
+    let old_selection = &selection
+    let &selection = 'inclusive'
 
     let oldVisualStart = getpos("'<")
     let oldVisualEnd = getpos("'>")
@@ -72,6 +74,8 @@ function! EasyClip#Move#MoveMotion(type)
 
     call setpos("'<", oldVisualStart)
     call setpos("'>", oldVisualEnd)
+
+    let &selection = old_selection
 endfunction
 
 function! EasyClip#Move#SetDefaultBindings()

--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -321,7 +321,7 @@ function! EasyClip#Paste#SwapPaste(forward)
     endif
 
     let s:pasteOverrideRegister = EasyClip#GetDefaultReg()
-    exec 'normal u.'
+    exec "normal u:silent call repeat#run(v:count)\<CR>"
     let s:pasteOverrideRegister = ''
 
     augroup SwapPasteMoveDetect


### PR DESCRIPTION
This PR fixes a couple of issues in my current setup:
* Fix `cut` when `selection` != `inclusive` #107
* For patched `vim-repeat` with remapped `.` key, call `repeat#run` directly