### PR TITLE
Issue #130: Do not attempt setting 'pastetoggle' in Neovim

### DIFF
--- a/autoload/EasyClip/Paste.vim
+++ b/autoload/EasyClip/Paste.vim
@@ -16,10 +16,10 @@ let s:lastPasteWasAutoFormatted = 0
 " Always toggle to 'paste mode' before pasting in insert mode
 " We have two methods of doing this here, both with different advantages/disadvantages
 " The first modifies the global value for pastetoggle, which may be undesirable if you want to bind
-" pastetoggle to something yourself
+" pastetoggle to something yourself (also Neovim deprecated pastetoggle, so this doesn't apply)
 " The second avoids the need to set the global pastetoggle but leaves insert mode briefly, which can
 " cause the indentation level to change sometimes (for eg. when hitting 'o' then immediately doing CTRL+V to paste something)
-if get(g:, 'EasyClipUseGlobalPasteToggle', 1)
+if get(g:, 'EasyClipUseGlobalPasteToggle', 1) && !has('nvim')
     set pastetoggle=<plug>PasteToggle
     imap <expr> <plug>EasyClipInsertModePaste '<plug>PasteToggle<C-r>' . EasyClip#GetDefaultReg() . '<plug>PasteToggle'
 else


### PR DESCRIPTION
Fix https://github.com/svermeulen/vim-easyclip/issues/130. Neovim deprecated `pastetoggle` in https://github.com/neovim/neovim/pull/22647, so trying to set that generates an error on startup and prevents the plugin from working.